### PR TITLE
ci: fix commit lint

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit $1

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,6 @@ export default function Home() {
           priority
         />
         <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2">This is dev branch</li>
           <li className="mb-2">
             Get started by editing{' '}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">


### PR DESCRIPTION
This pull request includes a new commit message hook and a minor content update to the homepage.

Commit message hook:

* [`.husky/commit-msg`](diffhunk://#diff-292bac03df29207ee254ba91cfc30951b10c50c0a9fff3a0768778cebe5f4c4aR1-R4): Added a script to enforce commit message linting using `commitlint`.

Homepage content update:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL16): Removed the list item "This is dev branch" from the homepage.