### PR TITLE
fix: fix token expiration bug

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -133,7 +133,7 @@ export const nextAuthConfig = {
 
       if (
         token.access_token_expired &&
-        token.access_token_expired < Date.now()
+        token.access_token_expired * 1000 < Date.now()
       ) {
         try {
           const refreshed = await fetch(


### PR DESCRIPTION
# Pull Request

## Description
Fix a bug where token always expire because exp in JWT and Date.now() of JavaScript is in different format


## Type of Change
Bug fix

## Screenshots
[If applicable screenshot in mobile and desktop]

## Checklist
- [x] Self-review completed
- [x] No new warnings
- [ ] run in production `pnpm run build` then `pnpm start`
- [ ] Documentation updated (checked it if no new handler added)
- [ ] Tests passing

## Related Issues (remove if empty)
Fixes #[issue_number] (e.g., Fixes #42)

## Notes
[Any additional context or concerns]
