### PR TITLE
Fix/66 setting won't load value when refresh

### DIFF
--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -4,7 +4,6 @@ import { redirect } from 'next/navigation';
 import { Divider } from '@/components/navigationBar/divider';
 import { VerificationStatus } from '@/components/setting-page/verificationStatus';
 import { DeleteAccountButton } from '@/components/setting-page/deleteAccountButton';
-import { AuthProvider } from '@/components/auth/authProvider';
 
 const page = async () => {
   const session = await auth();
@@ -25,9 +24,7 @@ const page = async () => {
             <p>{session?.user?.email}</p>
           </div>
         </div>
-        <AuthProvider>
-          <UpdateInformationForm />
-        </AuthProvider>
+        <UpdateInformationForm />
         <div className="flex flex-col gap-3 max-w-3xl w-full">
           <h1 className="text-2xl pt-3 font-semibold text-red-500">
             Delete account


### PR DESCRIPTION
# Pull Request

## Description
Fix a bug where values in the setting page won't load when refresh the page by removing the duplicate AuthProvider.

## Type of Change
Bug fix

## Checklist
- [x] Self-review completed
- [x] No new warnings
- [x] run in production `pnpm run build` then `pnpm start`
- [ ] Documentation updated (checked it if no new handler added)
- [ ] Tests passing

## Related Issues (remove if empty)
Fixes #66