### PR TITLE
fix: modify CircleX button to clear search and trigger a new search

### DIFF
--- a/src/components/home-page/searchBox.tsx
+++ b/src/components/home-page/searchBox.tsx
@@ -152,7 +152,16 @@ export function SearchBox() {
               {search && (
                 <Button
                   type="button"
-                  onClick={() => setSearch('')}
+                  onClick={() => {
+                    setSearch('');
+                    const params = new URLSearchParams(searchParams.toString());
+
+                    // Reset search query only
+                    params.delete('search');
+                    params.set('page', '1');
+
+                    router.push(`/?${params.toString()}`);
+                  }}
                   className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 rounded-full"
                   variant="ghost"
                   size="icon"


### PR DESCRIPTION
# Pull Request

## Description
Modifying the CircleX button to clear only the search input while preserving the other filters and immediately trigger a new search.


## Type of Change
Fix

## Screenshots
[If applicable screenshot in mobile and desktop]

## Checklist
- [x] Self-review completed
- [x] No new warnings
- [x] run in production `pnpm run build` then `pnpm start`
- [x] Documentation updated (checked it if no new handler added)
- [x] Tests passing