### PR TITLE
fix: navbar dropdown menu button link did not cover entire box

### DIFF
--- a/src/components/navigationBar/userDropdown.tsx
+++ b/src/components/navigationBar/userDropdown.tsx
@@ -31,10 +31,14 @@ export async function UserDropdown({ name, avatarUrl }: Props) {
         <DropdownMenuLabel>{name}</DropdownMenuLabel>
         <DropdownMenuSeparator />
         <DropdownMenuItem>
-          <Link href="/setting">Profile</Link>
+          <Link href="/setting" className="w-full">
+            Profile
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem>
-          <Link href="/dorm/register">Domitory</Link>
+          <Link href="/dorm/register" className="w-full">
+            Domitory
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem>
           <LogoutButton />


### PR DESCRIPTION
# Pull Request

## Description
MINOR CHANGE!!
Fixing the link effect did not cover entire Dormitory button and profile button 


## Type of Change
Fix bug

## Screenshots
Two buttons that is fixed
<img width="231" alt="Screenshot 2568-04-04 at 22 20 07" src="https://github.com/user-attachments/assets/dcad3cd8-2f81-47e4-ab0b-c5006ea6f170" />
<img width="309" alt="Screenshot 2568-04-04 at 22 20 12" src="https://github.com/user-attachments/assets/fd112069-d476-4556-8ca7-640407d58c88" />
Reference
<img width="264" alt="Screenshot 2568-04-04 at 22 20 17" src="https://github.com/user-attachments/assets/f44e1caf-ad08-4b81-a9b5-a2f2aa4b44d1" />


## Checklist
- [x] Self-review completed
- [x] No new warnings
- [x] run in production `pnpm run build` then `pnpm start`

## Notes
[Any additional context or concerns]
